### PR TITLE
Handle spatial normalization based on output_space in v0.22.1

### DIFF
--- a/main
+++ b/main
@@ -13,6 +13,7 @@ bl2bids
 WORKDIRNAME=$(pwd)/qsipworkdir
 outdir=$(pwd)/output
 
+space=$(jq -r .output_space config.json)
 resolution=$(jq -r .output_resolution config.json) 
 #sub=$(jq -r '._inputs[] | select(.id == "t1w") | .meta.subject' config.json)
 sub=$(jq -r '._inputs[0].meta.subject' config.json)
@@ -31,8 +32,17 @@ check_flip_bvecs=$(jq -r .check_flip_bvecs config.json)
 optional=""
 
 if [[ $dwi == *","* ]]; then 
-	echo "Multi dwi input found. Distortion group merge option: ${distortion_group_merge}"; 
-	optional="$optional --distortion-group-merge ${distortion_group_merge}";	
+    echo "Multi dwi input found. Distortion group merge option: ${distortion_group_merge}"; 
+    optional="$optional --distortion-group-merge ${distortion_group_merge}";    
+fi
+
+# Handling spatial normalization based on output_space
+if [[ $space == "MNI152NLin2009cAsym" ]]; then
+    echo "Performing normalization to MNI152NLin2009cAsym space."
+    optional="$optional --anatomical-template MNI152NLin2009cAsym"
+else
+    echo "Skipping normalization to template space, using T1w space."
+    optional="$optional --skip-anat-based-spatial-normalization"
 fi
 
 # boolean options


### PR DESCRIPTION
The QSIPrep `--template` option for spatial normalization to a template is deprecated, but we can still keep the interface consistent on Brainlife by adapting how we translate the options from `config.json`. 

QSIPrep v0.22.1 has the options `--skip-anat-based-spatial-normalization` and `--anatomical-template MNI152NLin2009cAsym` (see [usage](https://qsiprep.readthedocs.io/en/0.22.1/usage.html)), which I have attempted to map to the original functionality via this PR. 

I cannot find the original v0.15.3 documentation to confirm whether my understanding of the original is correct (the QSIPrep readthedocs only starts at v0.22.0), so it would be great if someone could review this.