### PR TITLE
Use qsiprep from path because binary moved

### DIFF
--- a/main
+++ b/main
@@ -92,7 +92,7 @@ export SINGULARITYENV_TEMPLATEFLOW_HOME=$PWD/templateflow
 # QSIPrep
 time singularity exec -e \
     docker://pennbbl/qsiprep:0.22.1 \
-    /usr/local/miniconda/bin/qsiprep \
+    qsiprep \
     --fs-license-file license.txt \
     --output-resolution $resolution \
     --denoise-method $denoise_method \


### PR DESCRIPTION
The QSIPrep binary has moved - this fixes the QSIPrep call to use the binary available in `PATH` to fix this error:

```
FATAL:   stat /usr/local/miniconda/bin/qsiprep: no such file or directory
```

See test output:

```
~: singularity exec -e docker://pennbbl/qsiprep:0.22.1 which qsiprep
INFO:    Using cached SIF image
INFO:    gocryptfs not found, will not be able to use gocryptfs
/opt/conda/envs/qsiprep/bin/qsiprep
```